### PR TITLE
chore: add package support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
     "type": "git",
     "url": "https://github.com/MetaMask/docusaurus-openrpc"
   },
+  "homepage": "https://github.com/MetaMask/docusaurus-openrpc",
+  "bugs": {
+    "url": "https://github.com/MetaMask/docusaurus-openrpc/issues"
+  },
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- add the missing npm homepage link for the package
- add the missing bugs.url link to the repository issue tracker

## Notes
- no runtime code, dependencies, package exports, generated files, or version fields changed

## Verification
- node manifest assertion for homepage and bugs.url
- npm pack --dry-run --ignore-scripts --json
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manifest-only metadata with no runtime, dependency, or export changes.
> 
> **Overview**
> Adds standard npm package metadata in `package.json`: a **`homepage`** pointing at the GitHub repo and a **`bugs.url`** entry for the issue tracker.
> 
> No runtime code, dependencies, exports, or version changes—manifest-only for registry and tooling discoverability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f50021b74af75ee5c9852a860433d9a39bc97615. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->